### PR TITLE
Rename to Wikisnakker

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['t/*.rb']
 end
 
-
+task default: :test

--- a/lib/wikidata/item/version.rb
+++ b/lib/wikidata/item/version.rb
@@ -1,5 +1,0 @@
-module Wikidata
-  module Item
-    VERSION = "0.0.1"
-  end
-end

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -1,4 +1,4 @@
-require "wikidata/item/version"
+require 'wikisnakker/version'
 
 require 'colorize'
 require 'digest/md5'
@@ -7,21 +7,21 @@ require 'open-uri/cached'
 require 'json'
 require 'set'
 
-class WikiData
+module Wikisnakker
 
   class Lookup
 
     def initialize(ids, resolve=true)
       @_used_props = Set.new
       @_hash = ids.compact.uniq.each_slice(50).map { |sliced|
-        page_args = { 
+        page_args = {
           action: 'wbgetentities',
           ids: sliced.join("|"),
           format: 'json',
         }
         url = 'https://www.wikidata.org/w/api.php?' + URI.encode_www_form(page_args)
         # warn "Fetching #{url}"
-        
+
         # If a property is set to another Wikidata article, resolve that
         # (e.g. set 'gender' to 'male' rather than 'Q6581097')
         # We don't know yet what that will resolve to, and we don't want
@@ -29,7 +29,7 @@ class WikiData
         # when done
         json = JSON.load(open(url).read, lambda { |h|
           if h.class == Hash and h['type'] == 'wikibase-entityid'
-            @_used_props << h['value']['numeric-id'] 
+            @_used_props << h['value']['numeric-id']
             h['resolved'] = lambda { prop(h['value']['numeric-id']) }
           end
         })
@@ -57,7 +57,7 @@ class WikiData
 
   end
 
-  class Item < WikiData
+  class Item
 
     def self.find(ids)
       _ids = [ids].flatten
@@ -77,7 +77,7 @@ class WikiData
       res = p(pid)
       wantarray.empty? ? p(pid).first : p(pid)
     end
-      
+
     def id
       @_raw['title']
     end

--- a/lib/wikisnakker/version.rb
+++ b/lib/wikisnakker/version.rb
@@ -1,0 +1,3 @@
+module Wikisnakker
+  VERSION = '0.0.1'
+end

--- a/t/multi.rb
+++ b/t/multi.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require 'wikidata/item'
+require 'wikisnakker'
 
 require 'open-uri/cached'
 
@@ -12,10 +12,10 @@ end
 
 describe 'data' do
 
-  subject { 
+  subject {
     # Members of the 13th Riigikogu
     ids = ids_from_claim('463:20530392')
-    WikiData::Item.find(ids)
+    Wikisnakker::Item.find(ids)
   }
 
   it 'should get multiple items' do

--- a/t/single.rb
+++ b/t/single.rb
@@ -1,9 +1,9 @@
 require 'minitest/autorun'
-require 'wikidata/item'
+require 'wikisnakker'
 
 describe 'Single Record' do
 
-  subject { WikiData::Item.find('Q312894') }
+  subject { Wikisnakker::Item.find('Q312894') }
 
   it 'should should know ID' do
     subject.id.must_equal 'Q312894'

--- a/wikisnakker.gemspec
+++ b/wikisnakker.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "minitest"
 end

--- a/wikisnakker.gemspec
+++ b/wikisnakker.gemspec
@@ -1,16 +1,16 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'wikidata/item/version'
+require 'wikisnakker/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "wikidata-item"
-  spec.version       = Wikidata::Item::VERSION
+  spec.name          = "wikisnakker"
+  spec.version       = Wikisnakker::VERSION
   spec.authors       = ["Tony Bowden"]
   spec.email         = ["tony@mysociety.org"]
   spec.summary       = %q{Fetch Wikidata.}
   spec.description   = %q{Turn Wikidata items into Ruby structures.}
-  spec.homepage      = "https://github.com/everypolitician/wikidata-item"
+  spec.homepage      = "https://github.com/everypolitician/wikisnakker"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
There is at least one gem that is using the `WikiData` namespace, so to avoid any potential problems this renames the gem to `Wikisnakker`, which is a subtle not the the [concept of "snaks" in Wikidata](https://meta.wikimedia.org/wiki/Wikidata/Notes/Entities_and_Snaks).