### PR TITLE
Refactor Item class

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -68,12 +68,12 @@ module Wikisnakker
       @id = raw['title']
       @labels = raw['labels']
       raw['claims'].each do |property_id, claims|
-        define_singleton_method property_id.to_sym do
-          send("#{property_id}s").first
-        end
-
         define_singleton_method "#{property_id}s".to_sym do
           claims.map { |c| Claim.new(c) }
+        end
+
+        define_singleton_method property_id.to_sym do
+          send("#{property_id}s").first
         end
       end
     end

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -63,13 +63,13 @@ module Wikisnakker
 
     def initialize(raw)
       @_raw = raw
-      raw['claims'].keys.each do |property_id|
+      raw['claims'].each do |property_id, claims|
         define_singleton_method property_id.to_sym do
-          property(property_id).first
+          send("#{property_id}s").first
         end
 
         define_singleton_method "#{property_id}s".to_sym do
-          property(property_id)
+          claims.map { |c| Claim.new(c) }
         end
       end
     end
@@ -84,10 +84,6 @@ module Wikisnakker
 
     def label(lang)
       labels[lang]['value']
-    end
-
-    def property(property_id)
-      (@_raw['claims'][property_id] || []).map { |c| Claim.new(c) }
     end
   end
 

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -63,13 +63,15 @@ module Wikisnakker
 
     def initialize(raw)
       @_raw = raw
-    end
+      raw['claims'].keys.each do |property_id|
+        define_singleton_method property_id.to_sym do
+          property(property_id).first
+        end
 
-    def method_missing(name)
-      handle = name.to_s.upcase.match(/P(\d+)(S?)/) || return
-      property_id, wantarray = handle.captures
-      res = property(property_id)
-      wantarray.empty? ? res.first : res
+        define_singleton_method "#{property_id}s".to_sym do
+          property(property_id)
+        end
+      end
     end
 
     def id
@@ -87,7 +89,7 @@ module Wikisnakker
     end
 
     def property(property_id)
-      (@_raw['claims']["P#{property_id}"] || []).map { |c| Claim.new(c) }
+      (@_raw['claims'][property_id] || []).map { |c| Claim.new(c) }
     end
   end
 

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -67,8 +67,8 @@ module Wikisnakker
 
     def method_missing(name)
       handle = name.to_s.upcase.match(/P(\d+)(S?)/) || return
-      pid, wantarray = handle.captures
-      res = p(pid)
+      property_id, wantarray = handle.captures
+      res = property(property_id)
       wantarray.empty? ? res.first : res
     end
 
@@ -86,8 +86,8 @@ module Wikisnakker
       labels[lang]['value']
     end
 
-    def p(pid)
-      (@_raw['claims']["P#{pid}"] || []).map { |c| Claim.new(c) }
+    def property(property_id)
+      (@_raw['claims']["P#{property_id}"] || []).map { |c| Claim.new(c) }
     end
   end
 

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -61,8 +61,12 @@ module Wikisnakker
       ids.size == 1 ? inflated.first : inflated
     end
 
+    attr_reader :id
+    attr_reader :labels
+
     def initialize(raw)
-      @_raw = raw
+      @id = raw['title']
+      @labels = raw['labels']
       raw['claims'].each do |property_id, claims|
         define_singleton_method property_id.to_sym do
           send("#{property_id}s").first
@@ -72,14 +76,6 @@ module Wikisnakker
           claims.map { |c| Claim.new(c) }
         end
       end
-    end
-
-    def id
-      @_raw['title']
-    end
-
-    def labels
-      @_raw['labels']
     end
 
     def label(lang)

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -78,8 +78,6 @@ module Wikisnakker
       @_raw['title']
     end
 
-    attr_reader :_raw
-
     def labels
       @_raw['labels']
     end


### PR DESCRIPTION
Remove the use of `method_missing` in favour of using `define_singleton_method`. This is preferable because to implement `method_missing` "properly" it's usually best to also override `respond_to?`. However because we already know the properties that will be defined we can simply define them and let ruby do the rest.