### PR TITLE
Don't error on missing properties

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -61,6 +61,8 @@ module Wikisnakker
       ids.size == 1 ? inflated.first : inflated
     end
 
+    PROPERTY_REGEX = /^P\d+s?$/
+
     attr_reader :id
     attr_reader :labels
 
@@ -76,6 +78,15 @@ module Wikisnakker
           send("#{property_id}s").first
         end
       end
+    end
+
+    def method_missing(method_name)
+      return super unless method_name.to_s.match(PROPERTY_REGEX)
+      method_name[-1] == 's' ? [] : nil
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      method_name.to_s.match(PROPERTY_REGEX) || super
     end
 
     def label(lang)

--- a/test/single_test.rb
+++ b/test/single_test.rb
@@ -52,4 +52,19 @@ describe 'Single Record' do
     gender = subject.P21
     gender.value.must_equal 'male'
   end
+
+  it 'should return nil for a singular missing property' do
+    subject.P999999999999.must_be_nil
+  end
+
+  it 'should return an empty array for a singular missing property' do
+    subject.P999999999999s.must_equal []
+  end
+
+  it 'should implement "respond_to?" correctly' do
+    subject.respond_to?(:P999999999999).must_equal true
+    subject.respond_to?(:P999999999999s).must_equal true
+    subject.respond_to?(:Ps).must_equal false
+    subject.respond_to?(:p42).must_equal false
+  end
 end


### PR DESCRIPTION
If there's a missing property then return nil if the user has requested
the singular property or an empty array if they've requested the plural.