### PR TITLE
Don't rely on JSON.recurse_proc

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -6,20 +6,6 @@ require 'open-uri'
 require 'json'
 require 'set'
 
-# Recursively calls passed _Proc_ if the parsed data structure is an _Array_ or _Hash_
-def recurse_proc(result, &proc)
-  case result
-  when Array
-    result.each { |x| recurse_proc x, &proc }
-    proc.call result
-  when Hash
-    result.each { |x, y| recurse_proc x, &proc; recurse_proc y, &proc }
-    proc.call result
-  else
-    proc.call result
-  end
-end
-
 module Wikisnakker
   class Lookup
     def self.find(ids)
@@ -50,10 +36,9 @@ module Wikisnakker
       pmap[key]
     end
 
-    def populate_with(other)
-      recurse_proc(@entities) do |result|
-        next unless result.is_a?(Hash) && result['type'] == 'wikibase-entityid'
-        result['value'] = other["Q#{result['value']['numeric-id']}"]
+    def populate_with(properties)
+      each_wikibase_entitiyid(@entities) do |entityid|
+        entityid['value'] = properties["Q#{entityid['value']['numeric-id']}"]
       end
     end
 
@@ -71,18 +56,45 @@ module Wikisnakker
       }
       url = 'https://www.wikidata.org/w/api.php?' + URI.encode_www_form(query)
       json = JSON.parse(open(url).read)
-      recurse_proc(json, &method(:resolve_wikibase_entityid))
+      save_wikibase_entityids(json)
       json
     end
 
     # If a property is set to another Wikidata article, resolve that
     # (e.g. set 'gender' to 'male' rather than 'Q6581097')
     # We don't know yet what that will resolve to, and we don't want
-    # to look them up one by one, so store a promise and bulk-resolve
-    # when done
-    def resolve_wikibase_entityid(result)
-      return unless result.is_a?(Hash) && result['type'] == 'wikibase-entityid'
-      @used_props << result['value']['numeric-id']
+    # to look them up one by one, so keep track of any entity ids we
+    # encounter and then resolve them later in '#populate_with'.
+    def save_wikibase_entityids(json)
+      each_wikibase_entitiyid(json) do |entityid|
+        @used_props << entityid['value']['numeric-id']
+      end
+    end
+
+    def each_wikibase_entitiyid(obj)
+      recurse_proc(obj) do |result|
+        next unless result.is_a?(Hash) && result['type'] == 'wikibase-entityid'
+        yield(result)
+      end
+    end
+
+    # Recursively calls passed _Proc_ if the parsed data structure is an _Array_ or _Hash_
+    # Taken from the json gem.
+    # @see http://git.io/v4Tf7
+    def recurse_proc(result, &proc)
+      case result
+      when Array
+        result.each { |x| recurse_proc x, &proc }
+        proc.call result
+      when Hash
+        result.each do |x, y|
+          recurse_proc x, &proc
+          recurse_proc y, &proc
+        end
+        proc.call result
+      else
+        proc.call result
+      end
     end
   end
 


### PR DESCRIPTION
In some cases other gems can redefine methods on the `JSON` object, e.g. yajl-ruby's `yajl/json_gem` compatibility layer. In the case of yajl-ruby it redefines `JSON.load` so that it doesn't understand the block argument to recursively call a proc for each object in the parsed JSON.

Rather than rely on this behaviour I've pulled in the `recurse_proc` method from the `JSON` gem and hidden it behind another method - `each_wikibase_entityid`. This hopefully make it a bit clearer what the code is trying to do while hiding some of the implementation detail.