### PR TITLE
Add a list of item properties

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -123,6 +123,10 @@ module Wikisnakker
       end
     end
 
+    def [](key)
+      send(key)
+    end
+
     def method_missing(method_name, *arguments, &block)
       return super unless method_name.to_s.match(PROPERTY_REGEX)
       method_name[-1] == 's' ? [] : nil

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -106,10 +106,12 @@ module Wikisnakker
 
     attr_reader :id
     attr_reader :labels
+    attr_reader :properties
 
     def initialize(raw)
       @id = raw['title']
       @labels = raw['labels']
+      @properties = raw['claims'].keys
       raw['claims'].each do |property_id, claims|
         define_singleton_method "#{property_id}s".to_sym do
           claims.map { |c| Claim.new(c) }

--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -123,7 +123,7 @@ module Wikisnakker
       end
     end
 
-    def method_missing(method_name)
+    def method_missing(method_name, *arguments, &block)
       return super unless method_name.to_s.match(PROPERTY_REGEX)
       method_name[-1] == 's' ? [] : nil
     end

--- a/test/single_test.rb
+++ b/test/single_test.rb
@@ -85,5 +85,9 @@ describe 'Record with URL' do
   it 'should have a list of properties' do
     subject.properties.must_equal ["P31", "P646", "P17", "P571", "P159", "P1142", "P856", "P154", "P488", "P214"]
   end
+
+  it 'should allow accessing properties using square brackets' do
+    subject[:P856].value.must_equal 'http://www.mdczimbabwe.org/'
+  end
 end
 

--- a/test/single_test.rb
+++ b/test/single_test.rb
@@ -81,5 +81,9 @@ describe 'Record with URL' do
   it 'should have a logo' do
     subject.P154.value.must_equal 'https://upload.wikimedia.org/wikipedia/commons/b/b0/Flag_of_the_Movement_for_Democratic_Change.svg'
   end
+
+  it 'should have a list of properties' do
+    subject.properties.must_equal ["P31", "P646", "P17", "P571", "P159", "P1142", "P856", "P154", "P488", "P214"]
+  end
 end
 


### PR DESCRIPTION
This exposes the properties that are available on an item, e.g. `P123`. It also adds `Item#[]`, which makes it easy to retrieve a property in a loop. So you can now do something like:

```ruby
item = Wikisnakker::Item.find('Q312894')
item.properties.each do |p|
  property = item[p]
end
```