### PR TITLE
Qualifiers#properties shouldn't error if there are none

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -242,6 +242,7 @@ module Wikisnakker
     attr_reader :properties
 
     def initialize(qualifier_snaks)
+      qualifier_snaks ||= {}
       @properties = qualifier_snaks.keys
       qualifier_snaks.each do |property_id, snaks|
         property "#{property_id}s".to_sym do

--- a/test/single_test.rb
+++ b/test/single_test.rb
@@ -148,4 +148,12 @@ describe 'qualifiers' do
   it 'should have a list of available qualifiers' do
     assert_equal ["P768", "P580"], position.qualifiers.properties
   end
+
+  it "shouldn't error if qualifiers are missing" do
+    VCR.use_cassette('roberto_noble') do
+      roberto_noble = Wikisnakker::Item.find('Q12341')
+      position = roberto_noble.P39s.first
+      assert_equal [], position.qualifiers.properties
+    end
+  end
 end


### PR DESCRIPTION
If there are no qualifier snaks then the Qualifiers class will receive
nil to its constructor. This causes an error when trying to introspect
the available properties. To prevent this error we simply default to an
empty hash for the qualifier snaks.

Fixes #23 