### PR TITLE
Handle asking for a label that doesn't exist

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -149,6 +149,7 @@ module Wikisnakker
     end
 
     def label(lang)
+      return nil unless labels.key?(lang)
       labels[lang]['value']
     end
   end

--- a/test/single_test.rb
+++ b/test/single_test.rb
@@ -17,6 +17,10 @@ describe 'Single Record' do
     subject.label('zh-hant').must_equal '尤漢·帕茨'
   end
 
+  it 'should not die with missing language' do
+    subject.label('zz').must_be_nil
+  end
+
   it 'should have a birth date' do
     dob = subject.P569
     "#{dob}".must_equal '1966-08-27'


### PR DESCRIPTION
If someone asks for a label that we don't have, return nil, rather than
blowing up.

Closes https://github.com/everypolitician/wikisnakker/issues/31