### PR TITLE
Handle lookups with no ids

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -21,7 +21,7 @@ module Wikisnakker
       entities = ids.each_slice(50).map do |id_slice|
         get(id_slice)['entities']
       end
-      @entities = entities.reduce(&:merge)
+      @entities = entities.reduce(&:merge) || {}
     end
 
     def properties

--- a/test/lookup_test.rb
+++ b/test/lookup_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+describe Wikisnakker::Lookup do
+  it 'should not fail if given an empty array' do
+    Wikisnakker::Lookup.new([]).values.must_equal([])
+  end
+end


### PR DESCRIPTION
We've had a couple of rebuilds fail with a Wikisnakker error.

https://rollbar.com/everypolitician/rebuilder/items/265/

```
Failed to build Hungary - Országgyűlés

rake aborted!
NoMethodError: undefined method `values' for nil:NilClass
/tmp/d20160516-3-jzjugr/vendor/bundle/bundler/gems/wikisnakker-c4939906c465/lib/wikisnakker.rb:32:in `values'
/tmp/d20160516-3-jzjugr/vendor/bundle/bundler/gems/wikisnakker-c4939906c465/lib/wikisnakker.rb:123:in `find'
/tmp/d20160516-3-jzjugr/lib/wikidata_lookup.rb:33:in `wikidata_results'
/tmp/d20160516-3-jzjugr/lib/wikidata_lookup.rb:17:in `to_hash'
/tmp/d20160516-3-jzjugr/lib/remotesource.rb:117:in `processed_wikidata'
/tmp/d20160516-3-jzjugr/lib/remotesource.rb:121:in `write'
/tmp/d20160516-3-jzjugr/lib/remotesource.rb:44:in `regenerate'
/tmp/d20160516-3-jzjugr/rake_helpers/combine_sources.rb:40:in `block in fetch_missing'
/tmp/d20160516-3-jzjugr/rake_helpers/combine_sources.rb:39:in `each'
/tmp/d20160516-3-jzjugr/rake_helpers/combine_sources.rb:39:in `fetch_missing'
/tmp/d20160516-3-jzjugr/rake_helpers/combine_sources.rb:17:in `block (2 levels) in <top (required)>'
Tasks: TOP => default => csvs => term_csvs:term_tables => ep-popolo-v1.0.json => transform:write => transform:ensure_legislature => transform:load => sources/merged.json => whittle:write => whittle:remove_warnings => whittle:load => verify:check_data => verify:load => merge_sources:sources/merged.csv => merge_sources:fetch_missing
(See full trace by running task with --trace)
```

I'm not sure exactly which wikidata id caused the error, and wasn't able to reproduce it with live data, but this fixes the cause of the error. The problem was that sometimes the lookup class received an empty array in the constructor. This caused it to set `@entities` to `nil` and therefore calls to `.values` were failing.