### PR TITLE
Move pry require into test_helper.rb

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -1,7 +1,6 @@
 require 'wikisnakker/version'
 
 require 'digest/md5'
-require 'pry'
 require 'open-uri'
 require 'json'
 require 'set'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'minitest/autorun'
 require 'minitest/around'
 require 'minitest/around/spec'
 require 'vcr'
+require 'pry'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'test/vcr_cassettes'


### PR DESCRIPTION
Because `pry` is a development dependency it's not included when someone includes it from GitHub in a `Gemfile`. This means that someone requiring the gem will get an error trying if they don't happen to have `pry` in their `Gemfile` already.