### PR TITLE
Reduce memory usage by freezing wikidata-entity string

### DIFF
--- a/lib/wikisnakker.rb
+++ b/lib/wikisnakker.rb
@@ -68,7 +68,7 @@ module Wikisnakker
 
     def each_wikibase_entitiyid(obj)
       recurse_proc(obj) do |result|
-        next unless result.is_a?(Hash) && result[:type] == 'wikibase-entityid'
+        next unless result.is_a?(Hash) && result[:type] == 'wikibase-entityid'.freeze
         yield(result)
       end
     end


### PR DESCRIPTION
This line of code gets called a _lot_ when we search recursively through results for references to other pages.

I've measured the impact of this change with the following code:

```ruby
Wikisnakker::Item.find('Q42')
```

Before this change was made running that line of code resulted in 1,375,689 bytes of memory and 33,206 objects being allocated. Over a megabyte of memory to retrieve a single record! With this change in place that code allocates 128,009 bytes of memory and 2,014 objects,
less than 0.2 megabytes!

Full report is here https://github.com/chrismytton/wikisnakker-memory-benchmark/commit/5626a3438d787f0450609e40ea7483ee8f8ef6fc.