### PR TITLE
Fix tests under Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script:
   - bundle exec rake test
   - bundle exec rake rubocop
 rvm:
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1
+  - 2.2
+  - 2.3.3
+  - 2.4.0

--- a/wikisnakker.gemspec
+++ b/wikisnakker.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.8.2'
   spec.add_development_dependency 'rubocop', '~> 0.34.2'
   spec.add_development_dependency 'vcr', '~> 3.0.0'
-  spec.add_development_dependency 'webmock', '~> 1.22.2'
+  spec.add_development_dependency 'webmock', '~> 2.3.2'
   spec.add_development_dependency 'minitest-around', '~> 0.3.2'
 end


### PR DESCRIPTION
This updates [Webmock to a version that works correctly with Ruby 2.4](https://github.com/bblimke/webmock/blob/1c3d473ddd123f2563a6807f0fc11ab2ef282c71/CHANGELOG.md#231) so that the test pass correctly under Ruby 2.4.

Fixes #52 