### PR TITLE
Don't use DynamicProperties in Item

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.9.0  2017-02-06
+  — Calculate data at run time via missing_method, rather than
+    generating singleton methods, to reduce memory usage.
+
 0.8.0  2017-01-06
   - Switch to using YAJL to parse the JSON from Wikidata. This greatly
     reduces memory usage.

--- a/lib/wikisnakker/version.rb
+++ b/lib/wikisnakker/version.rb
@@ -1,3 +1,3 @@
 module Wikisnakker
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
Rather than setting up lots of singleton methods for the data on each
Item, simply calculate it dynamically at run time.

This is an attempt to see what difference this makes to memory usage.