### PR TITLE
Make sure VCR dependency is at least 3.0.3

### DIFF
--- a/wikisnakker.gemspec
+++ b/wikisnakker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'minitest', '~> 5.8.2'
   spec.add_development_dependency 'rubocop', '~> 0.34.2'
-  spec.add_development_dependency 'vcr', '~> 3.0.0'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'webmock', '~> 2.3.2'
   spec.add_development_dependency 'minitest-around', '~> 0.3.2'
 end


### PR DESCRIPTION
Versions of VCR before this version didn't support webmock 2, so we want to make sure that developers always install a compatible version of VCR.

Part of https://github.com/everypolitician/everypolitician/issues/583